### PR TITLE
Fix levenshtein distance querying

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -349,12 +349,18 @@ BEGIN
         QUERY := format('
             SELECT
                 embedding,
-                levenshtein($2, (content->>''%s'')::TEXT) AS levenshtein_score
+                levenshtein(
+                    $2,
+                    LEFT((content->>''%s'')::TEXT, 255)
+                ) AS levenshtein_score
             FROM
                 memories
             WHERE
                 type = $1 AND
-                levenshtein($2, (content->>''%s'')::TEXT) <= $3
+                levenshtein(
+                    $2,
+                    LEFT((content->>''%s'')::TEXT, 255)
+                ) <= $3
             ORDER BY
                 levenshtein_score
             LIMIT


### PR DESCRIPTION
I think the schema had an edge case where if you had content >= 256 characters long all queries would fail because the query function would try to get the levenshtein distance between the query and the database content, but that function doesn't support texts with length >= 256.

```
{"code":"22023","details":null,"hint":null,"message":"levenshtein argument exceeds maximum length of 255 characters"}
at async MessageManager.handleMessage (file:///app/node_modules/@elizaos-plugins/client-discord/dist/index.js:2355:19)
at SupabaseDatabaseAdapter.getCachedEmbeddings (file:///app/node_modules/@elizaos-plugins/adapter-supabase/dist/index.js:145:13)
```