### PR TITLE
Fix: Ensure getRoomsForParticipants Returns Distinct Rooms

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,7 @@
   -- DROP TRIGGER IF EXISTS insert_into_memories ON memories;
   -- DROP FUNCTION remove_memories(text,uuid);
   -- DROP FUNCTION count_memories(text,uuid,boolean);
+  -- DROP FUNCTION check_similarity_and_insert(text,uuid,jsonb,uuid,vector,double precision,timestamp with time zone);
 
   DROP TABLE IF EXISTS relationships CASCADE;
   DROP TABLE IF EXISTS participants CASCADE;
@@ -25,6 +26,7 @@
   DROP TABLE IF EXISTS cache CASCADE;
   DROP TABLE IF EXISTS accounts CASCADE;
   DROP TABLE IF EXISTS knowledge CASCADE;
+
 
 
 -- -- Create Extensions
@@ -304,15 +306,6 @@ BEFORE INSERT ON memories_384
 FOR EACH ROW
 EXECUTE FUNCTION convert_timestamp();
 
--- CREATE OR REPLACE FUNCTION public.get_embedding_list(
---     query_table_name TEXT,
---     query_threshold INTEGER,
---     query_input TEXT,
---     query_field_name TEXT,
---     query_field_sub_name TEXT,
---     query_match_count INTEGER
--- )
-
 CREATE OR REPLACE FUNCTION "public"."get_embedding_list"(
     "query_table_name" "text", 
     "query_threshold" integer, 
@@ -388,7 +381,7 @@ $$;
 
 ALTER FUNCTION "public"."get_goals"("query_roomid" "uuid", "query_userid" "uuid", "only_in_progress" boolean, "row_count" integer) OWNER TO "postgres";
 
--- DROP FUNCTION check_similarity_and_insert(text,uuid,jsonb,uuid,vector,double precision,timestamp with time zone);
+
 
 CREATE OR REPLACE FUNCTION "public"."check_similarity_and_insert"("query_table_name" "text", "query_userid" "uuid", "query_content" "jsonb", "query_roomid" "uuid", "query_embedding" "vector", "similarity_threshold" double precision, "query_createdAt" timestamp with time zone)
 RETURNS "void"
@@ -577,5 +570,17 @@ BEGIN
 END;
 $$;
 
+
+CREATE OR REPLACE FUNCTION get_room_ids_by_user_ids(user_ids uuid[])
+RETURNS TABLE(roomId uuid) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT "roomId" 
+    FROM participants 
+    WHERE "userId" = ANY(user_ids)
+    GROUP BY "roomId"
+    HAVING COUNT(DISTINCT "userId") = array_length(user_ids, 1);
+END;
+$$ LANGUAGE plpgsql;
 
 COMMIT;

--- a/src/client.ts
+++ b/src/client.ts
@@ -586,10 +586,13 @@ export class SupabaseDatabaseAdapter extends DatabaseAdapter {
     }
 
     async getRoomsForParticipants(userIds: UUID[]): Promise<UUID[]> {
-        const { data, error } = await this.supabase
-            .from("participants")
-            .select("roomId")
-            .in("userId", userIds);
+        const { data, error } = await this.supabase.rpc(
+            'get_room_ids_by_user_ids', { user_ids: userIds });
+
+        // const { data, error } = await this.supabase
+        //     .from("participants")
+        //     .select("roomId",{distinct:true})
+        //     .in("userId", userIds)
 
         if (error) {
             throw new Error(
@@ -597,7 +600,7 @@ export class SupabaseDatabaseAdapter extends DatabaseAdapter {
             );
         }
 
-        return [...new Set(data.map((row) => row.roomId as UUID))] as UUID[];
+        return [...new Set(data.map((row) => row.roomid as UUID))] as UUID[];
     }
 
     async createRoom(roomId?: UUID): Promise<UUID> {


### PR DESCRIPTION
This PR fixes the issue where getRoomsForParticipants was retrieving more than 1000 rooms for some interactions and not returning distinct room IDs correctly.

## Changes
Added a new database function: get_room_ids_by_user_ids to efficiently fetch distinct room IDs based on participant user IDs.
Updated adapter-supabase client implementation that now calls the database function via supabase.rpc instead of querying the participants table directly.

### Key Implementation
New Supabase function:

```sql
CREATE OR REPLACE FUNCTION get_room_ids_by_user_ids(user_ids uuid[])
RETURNS TABLE(roomId uuid) AS $$
BEGIN
    RETURN QUERY
    SELECT "roomId" 
    FROM participants 
    WHERE "userId" = ANY(user_ids)
    GROUP BY "roomId"
    HAVING COUNT(DISTINCT "userId") = array_length(user_ids, 1);
END;
$$ LANGUAGE plpgsql;
Updated TypeScript function:
```

supabase client method update:

```typescript
async getRoomsForParticipants(userIds: UUID[]): Promise<UUID[]> {
    const { data, error } = await this.supabase.rpc(
        'get_room_ids_by_user_ids', { user_ids: userIds }
    );

    if (error) {
        throw new Error(
            `Error getting rooms by participants: ${error.message}`
        );
    }

    return [...new Set(data.map((row) => row.roomid as UUID))] as UUID[];
}
```

#### Why This Fix?
Ensures distinct rooms are retrieved.
Optimizes query performance by leveraging PostgreSQL functions instead of client-side filtering.
Reduces unnecessary data retrieval, preventing issues with excessive room counts.

#### How to test it:

into core/src/runtime.ts:
 
*const getRecentInteractions*
*rooms = await this.databaseAdapter.getRoomsForParticipants* // will return more than 1000 rooms depending on the users ids and interactions

after this fix, it will return only matching rooms for users and filter it as necessary.

